### PR TITLE
処理を厳密にし、ライブラリ化しました。

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,68 +1,12 @@
+#!/usr/bin/env python3
 import re
+import parser
+from pprint import pprint
+import sys
 
-# トーク行チェック
-def check_time(row):
-    return re.match("^[0-9][0-9]:[0-9][0-9] .+ .+$", row)
+out = parser.line_history_parse(sys.argv[1])
 
+pprint(out)
 
-# 日時行チェック
-def check_date(row):
-    return re.match("^[0-9][0-9][0-9][0-9]\.[0-9]+\.[0-9]+ ...$", row)
-
-
-# 空行チェック
-def check_empty_row(row):
-    return re.match("^$", row)
-
-
-# ファイル出力ヘッダー生成
-def create_file_header(outputs):
-    headers = ["日付", "時刻", "名前", "トーク"]
-    outputs.append(",".join(headers))
-
-
-# ファイル出力列生成
-def create_file_row(outputs, talk_row):
-    outputs.append(",".join(talk_row))
-
-
-read_file = "[LINE]LINUX 雑談質問部屋.txt"
-
-f = open(read_file, encoding="utf-8")
-rows = f.read().split("\n")
-f.close()
-
-outputs = []
-
-# ファイルのヘッダー作成
-create_file_header(outputs)
-
-start_talk = False
-talk_row = []
-talk_date = "2021.11.22 月曜日"
-
-for row in rows:
-    if check_time(row):
-        if start_talk:
-            create_file_row(outputs, talk_row)
-        start_talk = True
-        talk_row = []
-        talk_row.append(talk_date)
-        talk_row.extend(row.split(" "))
-        continue
-    if start_talk:
-        talk_row[3] += row
-        continue
-    if check_date(row):
-        start_talk = False
-        talk_date = row
-        continue
-    if check_empty_row(row):
-        start_talk = False
-        continue
-create_file_row(outputs, talk_row)
-
-outputs_csv = "\n".join(outputs)
-
-with open("test.csv", "w", encoding="utf-8") as f:
-    f.write(outputs_csv)
+#ith open("test.csv", "w", encoding="utf-8") as f:
+#   f.write(outputs_csv)

--- a/parser.py
+++ b/parser.py
@@ -1,0 +1,118 @@
+import re
+from datetime import datetime
+
+# トーク行チェック
+def is_talkline(line):
+    return re.match("^[0-9][0-9]:[0-5][0-9]\\t.*?\\t.*?$", line)
+
+def is_sysmesg(line):
+    return re.match("^[0-9][0-9]:[0-5][0-9]\\t.*$", line)
+
+# 日時行チェック
+def is_dateline(line):
+    return re.match("^[0-9]{4}/[0-1][0-9]/[0-3][0-9](...)$", line)
+
+
+# 空行チェック
+def is_emptyline(line):
+    return re.match("^$", line)
+
+
+# ファイル出力列生成
+#def create_file_row(outputs, talk_row):
+    #outputs_csv = "\n".join(outputs)
+
+
+def line_history_parse(filename):
+    f = open(filename, encoding="utf-8")
+    lines = f.read().split("\n")
+    f.close()
+
+    talks = []
+    talk = {}
+    talk_date = None
+    is_talking = False
+    date_str = None
+
+    is_prev_emptyline = False
+    is_talking_emptyline = False
+    is_talking_dateline = False
+    tmp_previous_line = None
+
+    header = lines.pop(0)
+    save_date = datetime.strptime(lines.pop(0).split("：")[1],'%Y/%m/%d %H:%M')
+
+    for line in lines:
+        #print(line)
+        # NOTE: システムメッセージ後の空行と3行目対策
+        if is_emptyline(line) and not is_talking:
+            continue
+
+        # 前行が日付ラインで現行がタブ文字含むチャット一行目なら...
+        if is_talking_dateline and is_talkline(line):
+            talks.append(talk)
+            is_talking = False
+            is_talking_dateline = False
+            date_str = tmp_previous_line.split("(")[0] # YYYY/MM/DD
+            tmp_previous_line = None
+            # このまま is_talklineブロックへ飛ぶ.
+        elif is_talking_dateline:
+            # 単純な日付ライン（チャットメッセージ上の）なら
+            talk["message"].append(tmp_previous_line)
+            is_talking_dateline = False
+            tmp_previous_line = None
+
+        # 日付チェック
+        if is_dateline(line):
+            if is_talking:
+                # 2行目以降にYYYY/MM/DD(W)が来てしまった場合を想定して次の行を確認。
+                is_talking_dateline = True
+                tmp_previous_line = line
+                continue
+            is_talking = False
+            date_str = line.split("(")[0] # YYYY/MM/DD
+            continue
+
+        # チャット一行目
+        if is_talkline(line):
+            if is_talking:
+                talks.append(talk)
+            is_talking = True
+            talk = {}
+            time_str = line.split("\t")[0]
+            date_obj = datetime.strptime(date_str + " " + time_str ,'%Y/%m/%d %H:%M')
+            talk["date"] = date_obj
+            talk["author"] = line.split("\t")[1]
+            talk["message"] = []
+            talk["message"].append(line.split("\t")[2])
+            continue
+
+        #####
+        # ここで、前行が空行なら追加する
+        if is_talking_emptyline:
+            talk["message"].append("")
+            is_taling_emptyline = False
+
+        # チャット二行目以降
+        if is_talking:
+            if is_emptyline(line):
+                is_talking_emptyline = True
+            else:
+                talk["message"].append(line)
+            continue
+
+        # システムメッセージ（タブ二つ）
+        if is_sysmesg(line):
+            if is_talking:
+                talks.append(talk)
+            talk = {}
+            talk["date"] = date_obj
+            talk["time"] = line.split("\t")[0]
+            talk["message"] = []
+            talk["message"].append(line.split("\t")[1])
+            talks.append(talk)
+            is_talking = False
+            continue
+
+        print("WARNING: unknown line: "+ line)
+    return header,save_date,talks


### PR DESCRIPTION
main.pyからparser.pyに分離し、ファイル名でline_history_parseを呼び出す形式に変更してみました。
返り値などのコメントアウトがまだなので、TODOですが、とりあえずは、
header(タイトル名）, 保存日時(datetime型), トーク履歴（list型）で返ります。
listの中身は、dictで、投稿日時の「date」（datetime型）と、author(str型）、message（list型）です。
messageは改行区切りのlistです。

ベタに２行目以降に、YYYY/MM/DD(W)形式を書かれるとパース出来ないのでその場合は次の行が新しい投稿の行か判断してます。
ただこれもよくないので、チャット文字列ではなく日付情報と認定する条件を、
「次の行が新しい投稿」かつ「YYYY/MM/DD(W)形式」かつ「+前の行が空行である」にしないといけないかもです。（これもTODO）